### PR TITLE
Add .extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,13 @@ await ppipe(1)
   .pipe(add, 1); //3
 ```
 
-## Additional Methods / Properties
+## Advanced Functionality
 
-### .with(ctx)
+### Chain Methods / Properties
+
+You can use these from the chain (after creating one with `ppipe(val)`).
+
+#### .with(ctx)
 
 Calls the following function in chain with the given `this` value (ctx). After calling `.with`
 the chain can be continued with the methods from the ctx.
@@ -180,10 +184,34 @@ await ppipe(10).with(new Example(5)).addToFoo(_); //15
 
 Look at the test/test.js for more examples.
 
-### .val
+#### .val
 
 Gets the current value from the chain. Will be a promise if any function in the chain returns a
 promise. Calling the chain with no parameters achieves the same result.
+
+### Extending Ppipe
+
+You can create an extended instance of ppipe via `.extend`.
+
+```javascript
+const newPipe = ppipe.extend({
+  divide (x, y) {
+    return x / y;
+  },
+  log(...params) {
+    console.log(...params);
+    return params[params.length - 1];
+  }
+});
+const res = await newPipe(10)
+  .pipe(x => x + 1)
+  .divide(_, 11)
+  .log("here is our x: ") //logs "here is our x: 1"
+  .pipe(x => x + 1) // 2
+```
+
+You can also call `.extend` on the extended ppipes. It will create a new ppipe with the new and
+existing extensions merged.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ppipe",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "piping without the operator support",
 	"main": "src/index.js",
 	"scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,107 +3,110 @@ const isPromise = val => val && isFn(val.then);
 const isUndef = val => typeof val === "undefined";
 const truthy = val => !isUndef(val) && val !== null;
 
-function ppipe(val, thisVal, err) {
-	const pipe = function(fn, ...params) {
-		if (isUndef(fn)) {
-			if (truthy(err)) {
-				throw err;
-			}
-			return val;
-		}
-		if (!isFn(fn)) {
-			throw new Error("first parameter to a pipe should be a function");
-		}
-		const callResultFn = value => {
-			let replacedPlaceHolder = false;
-			for (let i = params.length; i >= 0; i--) {
-				if (!(params[i] instanceof Placeholder)) {
-					continue;
+const createPpipe = (...extensions) => {
+	const ppipe = (val, thisVal, err) => {
+		const pipe = function(fn, ...params) {
+			if (isUndef(fn)) {
+				if (truthy(err)) {
+					throw err;
 				}
-				replacedPlaceHolder = true;
-				const pholdr = params[i];
-				const replacedParam = pholdr === ppipe._ ? value : value[pholdr.prop];
-				params.splice(i, 1, replacedParam);
+				return val;
 			}
-			if (!replacedPlaceHolder) {
-				params.splice(params.length, 0, value);
+			if (!isFn(fn)) {
+				throw new Error("first parameter to a pipe should be a function");
 			}
-			return fn.call(thisVal, ...params);
-		};
-		let res;
-		if (isPromise(val)) {
-			res = val.then(callResultFn);
-		} else {
-			try {
-				res = truthy(err) ? undefined : callResultFn(val);
-			} catch (e) {
-				err = e;
-			}
-		}
-		return ppipe(res, undefined, err);
-	};
-	const piped = new Proxy(pipe, {
-		get(target, name) {
-			switch (name) {
-				case "then":
-				case "catch": {
-					const res = truthy(err) ? Promise.reject(err) : Promise.resolve(val);
-					return (...params) => res[name](...params);
-				}
-				case "val":
-					if (truthy(err)) {
-						throw err;
+			const callResultFn = value => {
+				let replacedPlaceHolder = false;
+				for (let i = params.length; i >= 0; i--) {
+					if (!(params[i] instanceof Placeholder)) {
+						continue;
 					}
-					return val;
-				case "with":
-					return ctx => {
-						thisVal = ctx;
-						return piped;
-					};
-				case "pipe":
-					return piped;
-				case "bind":
-				case "call":
-				case "apply":
-					return (...params) => pipe[name](...params);
-			}
+					replacedPlaceHolder = true;
+					const pholdr = params[i];
+					const replacedParam = pholdr === _ ? value : value[pholdr.prop];
+					params.splice(i, 1, replacedParam);
+				}
+				if (!replacedPlaceHolder) {
+					params.splice(params.length, 0, value);
+				}
+				return fn.call(thisVal, ...params);
+			};
+			let res;
 			if (isPromise(val)) {
-				return (...params) =>
-					piped(x => {
-						if (isUndef(x[name])) {
-							throw new TypeError(`${name} is not defined on ${x}`);
+				res = val.then(callResultFn);
+			} else {
+				try {
+					res = truthy(err) ? undefined : callResultFn(val);
+				} catch (e) {
+					err = e;
+				}
+			}
+			return ppipe(res, undefined, err);
+		};
+		const piped = new Proxy(pipe, {
+			get(target, name) {
+				switch (name) {
+					case "then":
+					case "catch": {
+						const res = truthy(err)
+							? Promise.reject(err)
+							: Promise.resolve(val);
+						return (...params) => res[name](...params);
+					}
+					case "val":
+						if (truthy(err)) {
+							throw err;
 						}
-						return isFn(x[name]) ? x[name](...params) : x[name];
-					});
+						return val;
+					case "with":
+						return ctx => {
+							thisVal = ctx;
+							return piped;
+						};
+					case "pipe":
+						return piped;
+					case "bind":
+					case "call":
+					case "apply":
+						return (...params) => pipe[name](...params);
+				}
+				if (isPromise(val)) {
+					return (...params) =>
+						piped(x => {
+							if (isUndef(x[name])) {
+								throw new TypeError(`${name} is not defined on ${x}`);
+							}
+							return isFn(x[name]) ? x[name](...params) : x[name];
+						});
+				}
+				const fnExistsInCtx = truthy(thisVal) && isFn(thisVal[name]);
+				const valHasProp = !fnExistsInCtx && !isUndef(val[name]);
+				if (valHasProp || fnExistsInCtx) {
+					const ctx = truthy(thisVal) ? thisVal : val;
+					return (...params) =>
+						piped((...replacedParams) => {
+							const newParams = truthy(thisVal) ? replacedParams : params;
+							return !isFn(ctx[name]) ? ctx[name] : ctx[name](...newParams);
+						}, ...params);
+				}
 			}
-			if (!isUndef(val[name]) || (truthy(thisVal) && isFn(thisVal[name]))) {
-				const ctx = truthy(thisVal) ? thisVal : val;
-				return (...params) =>
-					piped(
-						(...replacedParams) =>
-							!isFn(ctx[name])
-								? ctx[name]
-								: truthy(thisVal)
-									? ctx[name](...replacedParams)
-									: ctx[name](...params),
-						...params
-					);
-			}
-		}
-	});
-	return piped;
-}
-
+		});
+		return piped;
+	};
+	ppipe._ = _;
+	ppipe.extend = newExtensions => createPpipe(...extensions, ...newExtensions);
+	return ppipe;
+};
 class Placeholder {
 	constructor(prop) {
 		this.prop = prop;
 	}
 }
 
-ppipe._ = new Proxy(new Placeholder(), {
+const _ = new Proxy(new Placeholder(), {
 	get(target, name) {
 		return new Placeholder(name);
 	}
 });
 
-module.exports = ppipe;
+module.exports = createPpipe();

--- a/test/examples.js
+++ b/test/examples.js
@@ -120,4 +120,25 @@ describe("check readme", function() {
 			.addToFoo();
 		assert.equal(res2, 15);
 	});
+
+	it("seventh example", async function() {
+		let logged = false;
+		const newPipe = ppipe.extend({
+			divide(x, y) {
+				return x / y;
+			},
+			log(...params) {
+				logged = true;
+				assert.equal(params[params.length - 1], 1);
+				return params[params.length - 1];
+			}
+		});
+		const res = await newPipe(10)
+			.pipe(x => x + 1)
+			.divide(_, 11)
+			.log("here is our x: ")
+			.pipe(x => x + 1);
+		assert.equal(res, 2);
+		assert.equal(logged, true);
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -444,4 +444,36 @@ describe("ppipe", function() {
 			.bind(null, (x, y) => x / y)(_, 10);
 		assert.equal(res, 1.1);
 	});
+
+	it("should support extensions", async () => {
+		const newPipe = ppipe.extend({
+			assertEqAndIncrement: (x, y) => {
+				assert.equal(x, y);
+				return x + 1;
+			}
+		});
+		const res = await newPipe(10)
+			.pipe(x => x + 1)
+			.assertEqAndIncrement(_, 11);
+		assert.equal(res, 12);
+	});
+
+	it("should support re-extending an extended ppipe", async () => {
+		const newPipe = ppipe.extend({
+			assertEqAndIncrement: (x, y) => {
+				assert.equal(x, y);
+				return x + 1;
+			}
+		});
+		const newerPipe = newPipe.extend({
+			divide: (x, y) => {
+				return x / y;
+			}
+		});
+		const res = await newerPipe(10)
+			.pipe(x => x + 1)
+			.assertEqAndIncrement(_, 11)
+			.divide(_, 12);
+		assert.equal(res, 1);
+	});
 });


### PR DESCRIPTION
## Description
Adds an extend method to the ppipe, which accepts an object with methods that will be available on chains. 

## Motivation and Context
Making reusable pipes helps modularity in a project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] All tests pass.
- [X] Test coverage is 100%.
- [X] I used prettier and eslint, which made me follow the style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
